### PR TITLE
Less restrictive requirement on Magento_Store module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "magento/framework": "103.0.*",
         "magento/module-customer": "103.0.*",
-        "magento/module-store": "101.1.0",
+        "magento/module-store": "101.1.*",
         "magento/module-directory": "100.4.*",
         "monolog/monolog": "^1.17",
         "firebase/php-jwt": "^5.0",


### PR DESCRIPTION
Magento, in theory, follows semantic versioning so there should be no reason to restrict dependency to a very specific version unless you do not use service contracts. Was it restricted on purpose? There is "magento/module-store":"101.1.1" available.