### PR TITLE
Fix dependencies: enable old versions before Magento 2.4.4. 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "vipps/module-login",
-    "description": "Sign In/Sing up using vipps mobile application",
+    "description": "Sign In/Sign up using vipps mobile application",
     "require": {
         "magento/framework": "103.0.*",
         "magento/module-customer": "103.0.*",


### PR DESCRIPTION
Hi!

After version 2.4.5 - no way to install module on Magento before 2.4.4. As i see it's related with strict updated requirements from Magento 2.4.4 for monolog/monolog and phpseclib/phpseclib, but as I see classnames, constructor aren't affected and latest versions of module  are compatible with previous releases. I suggest keep previous requirements and use the both versions.
In addition, fixed small typo in composer description.

Please review,
Thanks!    