### PR TITLE
Fix grammar in documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -73,7 +73,7 @@ new account using their existing data in Vipps or MobilePay.
 
 ![Create New Customer Account page with "Continue with Vipps" button and email registration link](./docs/images/4create-new-account.jpg)
 
-And, on the checkout page again allowing your customers to quickly log in not using
+And, on the checkout page again allowing your customers to quickly log in without using
 a traditional username and password, and fill in their information with the data that is already
 stored in Vipps MobilePay.
 
@@ -112,4 +112,3 @@ use Vipps MobilePay Login functionality.
 
 To use the app in test mode, you must use the
 [Vipps MobilePay test app](https://developer.vippsmobilepay.com/docs/knowledge-base/test-environment/#test-apps).
-:::

--- a/Technical-User-Guide.md
+++ b/Technical-User-Guide.md
@@ -52,7 +52,7 @@ When the account is confirmed, it will be linked with Vipps MobilePay account. T
 
 ### Create a new account
 
-If there is no account defined for customer then Adobe Commerce will try automatically create a new account using Vipps MobilePay account data.
+If there is no account defined for customer then Adobe Commerce will try to automatically create a new account using Vipps MobilePay account data.
 
 In the case when Adobe Commerce can't create an account automatically, the customer will be redirected to a standard Adobe Commerce registration form to complete it manually.
 This could happen, for example if Adobe Commerce required additional data for account creation that is missing in Vipps MobilePay account.
@@ -80,7 +80,7 @@ There are three ways to update the addresses and the customer is able to select 
 
 <!--![Logged-in with Vipps](account-logged-in-with-vipps.png)-->
 
-In the case when a behavior set to *ask first* and the Vipps MobilePay address(es) where changed, the customer will see a notification.
+In the case when a behavior is set to *ask first* and the Vipps MobilePay address(es) where changed, the customer will see a notification.
 
 ## Work with addresses
 


### PR DESCRIPTION
Conservative grammar fixes in INSTALL.md and Technical-User-Guide.md: missing word ('without'), missing verb ('is set to'), missing 'to' in infinitive, and removed a stray closing admonition marker.