### PR TITLE
Login security fixes: OAuth state, encrypted token storage, and address IDOR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
-## [2.6.1] - 2026-04-14
+## [2.6.2] - 2026-04-14
 ### Fixed
 - Fixed invalid state handling, PR #65 by @jonkjenn
 - Fixed an issue where applying Vipps address in Magento would allow to apply address not assigned to the vipps customer.
+
+### Changed
+- Updated Logging to support both Monolog 2 and 3
+
+## [2.6.1] - 2026-02-09
+### Fixed
+- Improved phone matching regex, PR #5 by @ed007m
 
 ## [2.6.0] - 2025-12-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ### Changed
 - Updated Logging to support both Monolog 2 and 3
+- Widened the `firebase/php-jwt` constraint to `^6.0 || ^7.0` (matching Magento) so installs can use
+  the patched 7.x release that addresses the weak-encryption advisory GHSA-2x45-7fc3-mxwq.
 
 ## [2.6.1] - 2026-02-09
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
-## [2.6.2] - 2026-04-14
+## [2.6.2] - 2026-06-08
+### Security
+- Encrypted the cached OAuth token payload in `vipps_login_authorization` at rest and fixed the
+  expiry-cleanup cutoff so stale token rows are pruned after 5 minutes.
+
 ### Fixed
 - Fixed invalid state handling, PR #65 by @jonkjenn
+- Restored the validated OAuth state on the token-retry redirect so concurrent/duplicate login
+  callbacks revalidate correctly after the state is consumed.
 - Fixed an issue where applying Vipps address in Magento would allow to apply address not assigned to the vipps customer.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
+## [2.6.1] - 2026-04-14
+### Fixed
+- Fixed invalid state handling, PR #65 by @jonkjenn
+- Fixed an issue where applying Vipps address in Magento would allow to apply address not assigned to the vipps customer.
+
 ## [2.6.0] - 2025-12-03
 
 ### Added

--- a/Controller/Login/ApplyAddress.php
+++ b/Controller/Login/ApplyAddress.php
@@ -106,9 +106,12 @@ class ApplyAddress extends AccountBase
                 $vippsCustomer = $this->vippsCustomerRepository->getByCustomer($customer->getDataModel());
                 $vippsAddress = $this->vippsCustomerAddressRepository->getById($addressId);
 
-                if (!$vippsAddress->getVippsCustomerId() == $vippsCustomer->getEntityId()) {
-                    $this->messageManager->addErrorMessage(__('We can\'t delete the address right now.'));
+                if ((int)$vippsAddress->getVippsCustomerId() !== (int)$vippsCustomer->getEntityId()) {
+                    $this->messageManager->addErrorMessage(__('Address was not found for the current customer.'));
+                    $resultRedirect->setPath('customer/address/index');
+                    return $resultRedirect;
                 }
+
                 $this->customerSession->setAddressFormData([
                     'telephone' => $vippsCustomer->getTelephone(),
                     'postcode' => $vippsAddress->getPostalCode(),

--- a/Controller/Login/Redirect.php
+++ b/Controller/Login/Redirect.php
@@ -125,8 +125,6 @@ class Redirect implements ActionInterface
         $code = $this->request->getParam('code');
         $state = $this->request->getParam('state');
 
-        $this->customerSession->setData(StateKey::DATA_KEY_STATE, $state);
-
         $resultRedirect = $this->resultRedirectFactory->create();
 
         try {
@@ -142,6 +140,8 @@ class Redirect implements ActionInterface
             if (!$this->isStateKeyValid($state)) {
                 throw new LocalizedException(__('Invalid state key.'));
             }
+
+            $this->customerSession->unsetData(StateKey::DATA_KEY_STATE);
 
             // get token
             $token = $this->tokenCommand->execute($code);
@@ -218,6 +218,6 @@ class Redirect implements ActionInterface
             return false;
         }
 
-        return $state == $sessionStateKey;
+        return $state === $sessionStateKey;
     }
 }

--- a/Controller/Login/Redirect.php
+++ b/Controller/Login/Redirect.php
@@ -151,6 +151,11 @@ class Redirect implements ActionInterface
             }
 
             if (!$token) {
+                // No token yet: a concurrent duplicate callback is still fetching it, so we retry
+                // until its payload is cached (bounded by checkAttempts above). The retry redirects
+                // back into this same controller, which validates the state again - but we already
+                // consumed it above, so put the validated value back for that next pass.
+                $this->customerSession->setData(StateKey::DATA_KEY_STATE, $state);
                 return $resultRedirect->setPath('vipps/login/redirect', ['code' => $code, 'state' => $state]);
             }
 

--- a/Gateway/Command/TokenCommand.php
+++ b/Gateway/Command/TokenCommand.php
@@ -21,6 +21,7 @@ namespace Vipps\Login\Gateway\Command;
 use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
 use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\HTTP\ClientFactory;
 use Magento\Framework\Serialize\SerializerInterface;
@@ -84,6 +85,11 @@ class TokenCommand
     private $moduleMetadata;
 
     /**
+     * @var EncryptorInterface
+     */
+    private $encryptor;
+
+    /**
      * @param ConfigInterface $config
      * @param SerializerInterface $serializer
      * @param ApiEndpointsInterface $apiEndpoints
@@ -92,6 +98,7 @@ class TokenCommand
      * @param LoggerInterface $logger
      * @param ResourceConnection $resourceConnection
      * @param ModuleMetadataInterface $moduleMetadata
+     * @param EncryptorInterface $encryptor
      */
     public function __construct(
         ConfigInterface $config,
@@ -101,7 +108,8 @@ class TokenCommand
         UrlInterface $url,
         LoggerInterface $logger,
         ResourceConnection $resourceConnection,
-        ModuleMetadataInterface $moduleMetadata
+        ModuleMetadataInterface $moduleMetadata,
+        EncryptorInterface $encryptor
     ) {
         $this->config = $config;
         $this->httpClientFactory = $httpClientFactory;
@@ -111,6 +119,7 @@ class TokenCommand
         $this->logger = $logger;
         $this->resourceConnection = $resourceConnection;
         $this->moduleMetadata = $moduleMetadata;
+        $this->encryptor = $encryptor;
     }
 
     /**
@@ -129,7 +138,7 @@ class TokenCommand
         }
 
         if (isset($authRecord['payload'])) {
-            return $this->prepareResponse($authRecord['payload']);
+            return $this->prepareResponse($this->encryptor->decrypt($authRecord['payload']));
         }
 
         $clientId = $this->config->getLoginClientId();
@@ -165,7 +174,7 @@ class TokenCommand
         $connection = $this->resourceConnection->getConnection('write');
         $connection->delete(
             $connection->getTableName('vipps_login_authorization'),
-            \sprintf('created_at < %s', $connection->quote((new \DateTime())->modify('-5 min')->format('Y-m-d H:i-s')))
+            \sprintf('created_at < %s', $connection->quote((new \DateTime())->modify('-5 min')->format('Y-m-d H:i:s')))
         );
 
         $select = $connection->select()
@@ -199,7 +208,7 @@ class TokenCommand
         return $connection->update(
             $connection->getTableName('vipps_login_authorization'),
             [
-                'payload' => $payload
+                'payload' => $this->encryptor->encrypt($payload)
             ],
             'code = ' . $connection->quote($code)
         );

--- a/Model/Logger.php
+++ b/Model/Logger.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright 2026 Vipps
+ * *
+ * * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * *
+ * * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL
+ * * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * * IN THE SOFTWARE.
+ */
+
+namespace Vipps\Login\Model;
+
+use DateTimeZone;
+use Magento\Payment\Gateway\ConfigInterface;
+use Monolog\Handler\HandlerInterface;
+
+class Logger extends \Monolog\Logger
+{
+    /**
+     * @param string $name
+     * @param ConfigInterface $config
+     * @param list<HandlerInterface> $handlers
+     * @param callable[] $processors
+     * @param DateTimeZone|null $timezone
+     */
+    public function __construct(
+        string $name,
+        ConfigInterface $config,
+        array $handlers = [],
+        array $processors = [],
+        ?DateTimeZone $timezone = null
+    ) {
+        if (!$config->getValue('debug')) {
+            unset($handlers['debug']);
+        }
+
+        parent::__construct($name, $handlers, $processors, $timezone);
+    }
+}

--- a/Model/Logger/Handler/Debug.php
+++ b/Model/Logger/Handler/Debug.php
@@ -21,8 +21,6 @@ namespace Vipps\Login\Model\Logger\Handler;
 use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Framework\Logger\Handler\Base;
 use Monolog\Logger;
-use Monolog\LogRecord;
-use Vipps\Login\Model\ConfigInterface;
 
 /**
  * Class Debug
@@ -35,45 +33,16 @@ class Debug extends Base
      */
     protected $fileName = '/var/log/vipps_login_debug.log'; //@codingStandardsIgnoreLine
 
-    /**
-     * @var int
-     */
-    protected $loggerType = Logger::DEBUG; //@codingStandardsIgnoreLine
-
-    /**
-     * @var ConfigInterface
-     */
-    private $config;
-
-    /**
-     * Debug constructor.
-     *
-     * @param DriverInterface $filesystem
-     * @param ConfigInterface|null $config
-     * @param string|null $filePath
-     */
     public function __construct(
         DriverInterface $filesystem,
-        ?ConfigInterface $config = null,
-        ?string $filePath = null
+        ?string $filePath = null,
+        ?string $fileName = null
     ) {
-        parent::__construct($filesystem, $filePath);
-        $this->config = $config;
-    }
+        // Monolog v3 vs v2 compatibility
+        $this->loggerType = class_exists(\Monolog\Level::class)
+            ? \Monolog\Level::Debug->value
+            : Logger::DEBUG;
 
-    /**
-     * {@inheritdoc}
-     *
-     * @param array $record
-     *
-     * @return bool
-     */
-    public function isHandling(LogRecord $record): bool
-    {
-        if ($this->config && (bool)$this->config->isDebug()) {
-            return parent::isHandling($record);
-        }
-
-        return false;
+        parent::__construct($filesystem, $filePath, $fileName);
     }
 }

--- a/Model/Logger/Handler/Error.php
+++ b/Model/Logger/Handler/Error.php
@@ -20,6 +20,7 @@ namespace Vipps\Login\Model\Logger\Handler;
 
 use Magento\Framework\Logger\Handler\Base;
 use Monolog\Logger;
+use Magento\Framework\Filesystem\DriverInterface;
 
 /**
  * Class Error
@@ -32,8 +33,16 @@ class Error extends Base
      */
     protected $fileName = '/var/log/vipps_login_exception.log'; //@codingStandardsIgnoreLine
 
-    /**
-     * @var int
-     */
-    protected $loggerType = Logger::INFO; //@codingStandardsIgnoreLine
+    public function __construct(
+        DriverInterface $filesystem,
+        ?string $filePath = null,
+        ?string $fileName = null
+    ) {
+        // Monolog v3 vs v2 compatibility
+        $this->loggerType = class_exists(\Monolog\Level::class)
+            ? \Monolog\Level::Error->value
+            : Logger::ERROR;
+
+        parent::__construct($filesystem, $filePath, $fileName);
+    }
 }

--- a/Test/Unit/Controller/Login/ApplyAddressTest.php
+++ b/Test/Unit/Controller/Login/ApplyAddressTest.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Copyright 2020 Vipps
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+namespace Vipps\Login\Test\Unit\Controller\Login;
+
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Customer\Model\Customer;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use Magento\Framework\Controller\Result\RedirectFactory;
+use Magento\Framework\Message\ManagerInterface;
+use Magento\Framework\Session\SessionManagerInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Vipps\Login\Api\Data\VippsCustomerAddressInterface;
+use Vipps\Login\Api\Data\VippsCustomerInterface;
+use Vipps\Login\Api\VippsCustomerAddressRepositoryInterface;
+use Vipps\Login\Api\VippsCustomerRepositoryInterface;
+use Vipps\Login\Controller\Login\ApplyAddress;
+
+/**
+ * Covers the VIPPS-51 IDOR fix: the address id comes straight from a request param, so the
+ * controller must verify the address belongs to the current customer before prefilling its PII,
+ * and must not reject a legitimate owner due to int-vs-string id typing.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class ApplyAddressTest extends TestCase
+{
+    /** @var RedirectFactory|MockObject */
+    private $resultRedirectFactory;
+
+    /** @var Redirect|MockObject */
+    private $resultRedirect;
+
+    /** @var RequestInterface|MockObject */
+    private $request;
+
+    /** @var SessionManagerInterface|MockObject */
+    private $customerSession;
+
+    /** @var ManagerInterface|MockObject */
+    private $messageManager;
+
+    /** @var VippsCustomerAddressRepositoryInterface|MockObject */
+    private $vippsCustomerAddressRepository;
+
+    /** @var VippsCustomerRepositoryInterface|MockObject */
+    private $vippsCustomerRepository;
+
+    /** @var ApplyAddress */
+    private $action;
+
+    protected function setUp(): void
+    {
+        $this->resultRedirect = $this->createMock(Redirect::class);
+        $this->resultRedirect->method('setPath')->willReturnSelf();
+
+        $this->resultRedirectFactory = $this->createMock(RedirectFactory::class);
+        $this->resultRedirectFactory->method('create')->willReturn($this->resultRedirect);
+
+        $this->request = $this->getMockBuilder(RequestInterface::class)->getMockForAbstractClass();
+
+        $this->customerSession = $this->getMockBuilder(SessionManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['getCustomer', 'setAddressFormData'])
+            ->getMockForAbstractClass();
+
+        $customer = $this->getMockBuilder(Customer::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getDataModel'])
+            ->getMock();
+        $customer->method('getDataModel')->willReturn($this->createMock(CustomerInterface::class));
+        $this->customerSession->method('getCustomer')->willReturn($customer);
+
+        $this->messageManager = $this->getMockBuilder(ManagerInterface::class)->getMockForAbstractClass();
+        $this->vippsCustomerAddressRepository = $this->createMock(VippsCustomerAddressRepositoryInterface::class);
+        $this->vippsCustomerRepository = $this->createMock(VippsCustomerRepositoryInterface::class);
+        $logger = $this->getMockBuilder(LoggerInterface::class)->getMockForAbstractClass();
+
+        $objectManager = new ObjectManager($this);
+        $this->action = $objectManager->getObject(ApplyAddress::class, [
+            'resultRedirectFactory' => $this->resultRedirectFactory,
+            'request' => $this->request,
+            'logger' => $logger,
+            'customerSession' => $this->customerSession,
+            'messageManager' => $this->messageManager,
+            'vippsCustomerAddressRepository' => $this->vippsCustomerAddressRepository,
+            'vippsCustomerRepository' => $this->vippsCustomerRepository,
+        ]);
+    }
+
+    /**
+     * An address owned by a different vipps customer must be rejected: error message, redirect to the
+     * address list, and crucially no PII written into the session form data.
+     */
+    public function testRejectsAddressOwnedByAnotherCustomer(): void
+    {
+        $this->request->method('getParam')->with('id', false)->willReturn('42');
+
+        $vippsCustomer = $this->createMock(VippsCustomerInterface::class);
+        $vippsCustomer->method('getEntityId')->willReturn(7);
+        $this->vippsCustomerRepository->method('getByCustomer')->willReturn($vippsCustomer);
+
+        $vippsAddress = $this->createMock(VippsCustomerAddressInterface::class);
+        $vippsAddress->method('getVippsCustomerId')->willReturn('999');
+        $this->vippsCustomerAddressRepository->method('getById')->with('42')->willReturn($vippsAddress);
+
+        $this->messageManager->expects($this->once())->method('addErrorMessage');
+        $this->customerSession->expects($this->never())->method('setAddressFormData');
+        $this->resultRedirect->expects($this->once())->method('setPath')->with('customer/address/index');
+
+        $this->assertSame($this->resultRedirect, $this->action->execute());
+    }
+
+    /**
+     * The legitimate owner must be accepted even when the two ids differ only by type (a string
+     * '7' from the DB vs an int 7 on a freshly saved model) — the int cast guards that.
+     */
+    public function testAppliesOwnAddressWhenIdsMatchAcrossIntAndString(): void
+    {
+        $this->request->method('getParam')->with('id', false)->willReturn('42');
+
+        $vippsCustomer = $this->createMock(VippsCustomerInterface::class);
+        $vippsCustomer->method('getEntityId')->willReturn(7);
+        $vippsCustomer->method('getTelephone')->willReturn('+4712345678');
+        $this->vippsCustomerRepository->method('getByCustomer')->willReturn($vippsCustomer);
+
+        $vippsAddress = $this->createMock(VippsCustomerAddressInterface::class);
+        $vippsAddress->method('getVippsCustomerId')->willReturn('7');
+        $vippsAddress->method('getPostalCode')->willReturn('0123');
+        $vippsAddress->method('getRegion')->willReturn('Oslo');
+        $vippsAddress->method('getCountry')->willReturn('NO');
+        $vippsAddress->method('getStreetAddress')->willReturn('Karl Johans gate 1');
+        $this->vippsCustomerAddressRepository->method('getById')->willReturn($vippsAddress);
+
+        $this->customerSession->expects($this->once())->method('setAddressFormData');
+        $this->messageManager->expects($this->never())->method('addErrorMessage');
+        $this->resultRedirect->expects($this->once())
+            ->method('setPath')
+            ->with('customer/address/new', ['vipps_address_id' => '42']);
+
+        $this->action->execute();
+    }
+}

--- a/Test/Unit/Gateway/Command/TokenCommandTest.php
+++ b/Test/Unit/Gateway/Command/TokenCommandTest.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Copyright 2020 Vipps
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+namespace Vipps\Login\Test\Unit\Gateway\Command;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use Magento\Framework\Encryption\EncryptorInterface;
+use Magento\Framework\HTTP\ClientFactory;
+use Magento\Framework\HTTP\ClientInterface;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Framework\UrlInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Vipps\Login\Api\ApiEndpointsInterface;
+use Vipps\Login\Api\ModuleMetadataInterface;
+use Vipps\Login\Gateway\Command\TokenCommand;
+use Vipps\Login\Model\ConfigInterface;
+
+/**
+ * Covers the VIPPS-51 token-storage hardening: the cached token payload must be encrypted at rest
+ * (and decrypted when a duplicate callback reuses it), and the stale-row cleanup must use a valid
+ * datetime format so rows actually expire.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class TokenCommandTest extends TestCase
+{
+    /** @var ConfigInterface|MockObject */
+    private $config;
+
+    /** @var SerializerInterface|MockObject */
+    private $serializer;
+
+    /** @var ApiEndpointsInterface|MockObject */
+    private $apiEndpoints;
+
+    /** @var ClientFactory|MockObject */
+    private $httpClientFactory;
+
+    /** @var UrlInterface|MockObject */
+    private $url;
+
+    /** @var LoggerInterface|MockObject */
+    private $logger;
+
+    /** @var ResourceConnection|MockObject */
+    private $resourceConnection;
+
+    /** @var ModuleMetadataInterface|MockObject */
+    private $moduleMetadata;
+
+    /** @var EncryptorInterface|MockObject */
+    private $encryptor;
+
+    /** @var AdapterInterface|MockObject */
+    private $connection;
+
+    /** @var TokenCommand */
+    private $tokenCommand;
+
+    protected function setUp(): void
+    {
+        $this->config = $this->createMock(ConfigInterface::class);
+        $this->serializer = $this->createMock(SerializerInterface::class);
+        $this->apiEndpoints = $this->createMock(ApiEndpointsInterface::class);
+        $this->httpClientFactory = $this->createMock(ClientFactory::class);
+        $this->url = $this->createMock(UrlInterface::class);
+        $this->logger = $this->getMockBuilder(LoggerInterface::class)->getMockForAbstractClass();
+        $this->resourceConnection = $this->createMock(ResourceConnection::class);
+        $this->moduleMetadata = $this->createMock(ModuleMetadataInterface::class);
+        $this->encryptor = $this->createMock(EncryptorInterface::class);
+
+        $select = $this->createMock(Select::class);
+        $select->method('from')->willReturnSelf();
+        $select->method('where')->willReturnSelf();
+
+        $this->connection = $this->createMock(AdapterInterface::class);
+        $this->connection->method('getTableName')->willReturnArgument(0);
+        $this->connection->method('quote')->willReturnCallback(static fn($v) => "'" . $v . "'");
+        $this->connection->method('select')->willReturn($select);
+
+        $this->resourceConnection->method('getConnection')->willReturn($this->connection);
+
+        $objectManager = new ObjectManager($this);
+        $this->tokenCommand = $objectManager->getObject(TokenCommand::class, [
+            'config' => $this->config,
+            'serializer' => $this->serializer,
+            'apiEndpoints' => $this->apiEndpoints,
+            'httpClientFactory' => $this->httpClientFactory,
+            'url' => $this->url,
+            'logger' => $this->logger,
+            'resourceConnection' => $this->resourceConnection,
+            'moduleMetadata' => $this->moduleMetadata,
+            'encryptor' => $this->encryptor,
+        ]);
+    }
+
+    /**
+     * A duplicate/concurrent callback finds the payload already cached: it must decrypt the stored
+     * value and must NOT call Vipps again (the authorization code is single-use).
+     */
+    public function testReusePathDecryptsCachedPayloadAndSkipsVipps(): void
+    {
+        $code = 'auth-code';
+        $cipher = 'ENCRYPTED_PAYLOAD';
+        $body = '{"access_token":"abc"}';
+
+        $this->connection->method('fetchRow')->willReturn([
+            'code' => $code,
+            'payload' => $cipher,
+            'created_at' => '2026-06-08 10:00:00',
+        ]);
+
+        $this->encryptor->expects($this->once())
+            ->method('decrypt')
+            ->with($cipher)
+            ->willReturn($body);
+
+        // No 'id_token' key -> getPayload() short-circuits, so no JWKS/JWT round trip in the test.
+        $this->serializer->method('unserialize')->with($body)->willReturn(['access_token' => 'abc']);
+
+        $this->httpClientFactory->expects($this->never())->method('create');
+
+        $result = $this->tokenCommand->execute($code);
+
+        $this->assertSame('abc', $result['access_token']);
+        $this->assertArrayHasKey('id_token_payload', $result);
+        $this->assertNull($result['id_token_payload']);
+    }
+
+    /**
+     * First callback for a code: no cached payload yet, so it exchanges the code with Vipps and must
+     * encrypt the response body before persisting it.
+     */
+    public function testStorePathEncryptsTokenPayloadBeforePersisting(): void
+    {
+        $code = 'auth-code';
+        $body = '{"access_token":"abc"}';
+        $cipher = 'CIPHER';
+
+        // No row first, then a row without payload after the insert.
+        $this->connection->method('fetchRow')->willReturnOnConsecutiveCalls(false, ['code' => $code]);
+        $this->connection->expects($this->once())->method('insert');
+
+        $captured = null;
+        $this->connection->expects($this->once())
+            ->method('update')
+            ->willReturnCallback(function ($table, $data, $where) use (&$captured) {
+                $captured = $data;
+                return 1;
+            });
+
+        $this->config->method('getLoginClientId')->willReturn('client-id');
+        $this->config->method('getLoginClientSecret')->willReturn('client-secret');
+        $this->apiEndpoints->method('getTokenEndpoint')->willReturn('https://example.test/token');
+        $this->url->method('getUrl')->willReturn('https://shop.test/vipps/login/redirect/');
+        $this->moduleMetadata->method('getSystemName')->willReturn('Magento');
+        $this->moduleMetadata->method('getSystemVersion')->willReturn('2.4.8');
+        $this->moduleMetadata->method('getModuleName')->willReturn('Vipps_Login');
+        $this->moduleMetadata->method('getModuleVersion')->willReturn('2.6.2');
+
+        $client = $this->createMock(ClientInterface::class);
+        $client->method('getBody')->willReturn($body);
+        $this->httpClientFactory->method('create')->willReturn($client);
+
+        $this->encryptor->expects($this->once())->method('encrypt')->with($body)->willReturn($cipher);
+        $this->serializer->method('unserialize')->with($body)->willReturn(['access_token' => 'abc']);
+
+        $result = $this->tokenCommand->execute($code);
+
+        $this->assertSame($cipher, $captured['payload'], 'The persisted payload must be the ciphertext.');
+        $this->assertSame('abc', $result['access_token']);
+    }
+
+    /**
+     * Regression guard for the cleanup bug: the 5-minute cutoff was formatted 'Y-m-d H:i-s' (a dash
+     * before seconds), which produced a malformed datetime so stale token rows were never pruned.
+     */
+    public function testStaleCleanupUsesValidDatetimeFormat(): void
+    {
+        $captured = null;
+        $this->connection->method('delete')
+            ->willReturnCallback(function ($table, $where) use (&$captured) {
+                $captured = $where;
+                return 1;
+            });
+
+        // Short-circuit on the reuse path so the test stays focused on the cleanup call.
+        $this->connection->method('fetchRow')->willReturn(['code' => 'c', 'payload' => 'X']);
+        $this->encryptor->method('decrypt')->willReturn('{}');
+        $this->serializer->method('unserialize')->willReturn(['access_token' => 'a']);
+
+        $this->tokenCommand->execute('c');
+
+        $this->assertNotNull($captured, 'The cleanup delete should have run.');
+        $this->assertMatchesRegularExpression(
+            "/^created_at < '\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}'$/",
+            $captured,
+            'Cutoff must use Y-m-d H:i:s (colon before seconds), not the malformed H:i-s.'
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "magento/module-store": "101.1.*",
         "magento/module-directory": "100.4.*",
         "monolog/monolog": "^3.0",
-        "firebase/php-jwt": "^6.0",
+        "firebase/php-jwt": "^6.0 || ^7.0",
         "phpseclib/phpseclib": "2.0.*||^3.0",
         "psr/log": "^1.0||^2.0||^3.0",
         "php": "^8.2||^8.3||^8.4"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^8.3 || ^8.4"
     },
     "type": "magento2-module",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
         "firebase/php-jwt": "^6.0",
         "phpseclib/phpseclib": "2.0.*||^3.0",
         "psr/log": "^1.0||^2.0||^3.0",
-        "php": "^8.3 || ^8.4"
+        "php": "^8.2||^8.3||^8.4"
     },
     "type": "magento2-module",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -41,15 +41,16 @@
     <preference for="Vipps\Login\Api\Block\ClassPoolInterface" type="Vipps\Login\Model\Block\ClassPool" />
 
     <!-- Defining Vipps_Login logger object to process logs into vipps_login files -->
-    <virtualType name="Vipps\Login\Model\Logger" type="Monolog\Logger">
+    <type name="Vipps\Login\Model\Logger">
         <arguments>
             <argument name="name" xsi:type="string">vipps</argument>
+            <argument name="config" xsi:type="object">Vipps\Payment\GatewayEpayment\Config\Config</argument>
             <argument name="handlers"  xsi:type="array">
                 <item name="error" xsi:type="object">Vipps\Login\Model\Logger\Handler\Error</item>
                 <item name="debug" xsi:type="object">Vipps\Login\Model\Logger\Handler\Debug</item>
             </argument>
         </arguments>
-    </virtualType>
+    </type>
 
     <type name="Magento\Customer\Api\AddressRepositoryInterface">
         <plugin name="Vipps\Login\Plugin\AddressSave" type="Vipps\Login\Plugin\AddressSave"/>

--- a/i18n/fi_FI.csv
+++ b/i18n/fi_FI.csv
@@ -6,3 +6,4 @@
 "Register with","Rekisteröidy"
 "Continue as %1","Jatka nimellä %1"
 "MobilePay","MobilePaylla"
+"Address was not found for the current customer.","Nykyisen asiakkaan osoitetta ei löytynyt."

--- a/i18n/nb_NO.csv
+++ b/i18n/nb_NO.csv
@@ -94,3 +94,4 @@ Debug,Feilsøk
 "Receive offers via SMS","Få tilbud på SMS"
 "I would like to receive digital marketing","Jeg vil motta digital markedsføring"
 "Get customized offers","Få tilpassede tilbud"
+"Address was not found for the current customer.","Adressen ble ikke funnet for den nåværende kunden."


### PR DESCRIPTION
This bundles three security fixes for Vipps Login (plus Monolog 2/3 logging compatibility). It includes #65 (invalid state handling) by @jonkjenn as the original commit.

### 1. OAuth `state` validation (CSRF) — includes #65
`Redirect` wrote the request's `state` into the session before comparing it, so any value validated and the anti-CSRF check was effectively bypassed. #65 fixes this (validate against the stored state, single-use, strict comparison). This PR also restores the validated state on the token-retry redirect, so the duplicate/concurrent-callback retry keeps working now that the state is single-use.

### 2. Cached tokens encrypted at rest
`TokenCommand` cached the full token-endpoint response (access/id/refresh tokens) in `vipps_login_authorization.payload` in plaintext, and the 5-minute cleanup used a malformed date format (`Y-m-d H:i-s`), so stale rows were never pruned. The payload is now encrypted with `EncryptorInterface` (decrypted only on the duplicate-callback reuse path), and the cutoff is corrected to `Y-m-d H:i:s`. The cache is kept because the authorization code is single-use, so concurrent callbacks must read the shared row rather than re-exchange the code.

### 3. Address apply IDOR
`ApplyAddress` read an auto-increment `id` from the request and loaded that address with a broken, non-blocking ownership check, letting any logged-in customer prefill the new-address form with another customer's address data. It now performs a blocking ownership check (early return, int-cast id comparison) and rejects addresses that don't belong to the current customer.

### Also
- Logging now works with both Monolog 2 and 3.

## Testing

**Unit tests** (`Test/Unit`):
- `TokenCommandTest` — payload is encrypted before being persisted; on a duplicate callback the cached payload is decrypted and the token endpoint is not called again; cleanup uses a valid `Y-m-d H:i:s` cutoff.
- `ApplyAddressTest` — an address owned by another customer is rejected without leaking its data; the owner's own address is accepted (including int/string id typing).

**Manual verification** on a live Magento 2.4.8 install:
- Vipps login and new-account registration work.
- A forged/altered `state` on the callback is rejected ("Invalid state key"); a replayed callback link is rejected.
- After login, the stored `payload` is encrypted (ciphertext, no plaintext token in the column); stale rows are pruned on the next login.
- Loading another customer's address id is blocked; the owner's own address still prefills.
- Duplicate callbacks degrade gracefully (no redirect loop); applying a Vipps address from the account UI still works.
